### PR TITLE
Init from environment vars.  Channel use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,19 @@
 
 Go (golang) client library for logging to https://logentries.com/ via TLS.  Compatible with http://golang.org/pkg/log/#Logger
 
-* Uses a buffered chan to avoid blocking the application.  Will drop log messages if the chan is full.
+* Uses a buffered chan to avoid blocking the application.  Will write to std err if the chan is full.
 
 Example usage:
+
+If the environment variable `LOGENTRIES_TOKEN` is set before init() begins then simply import for side effects to log to Logentries:
+
+```
+import (
+	_ "github.com/GeoNet/log/logentries"
+)
+```
+
+`logentries.Init("LOGENTRIES_TOKEN")` can be called if needed:
 
 ```
 package main


### PR DESCRIPTION
Allow init from an environment variable (to be a little more 12 factor).
Does not break the current public api.

Correct way to check if a chan is ready (instead of using len).

Resolves #1 and #2