### PR TITLE
Option for blocking logger. Resolves #5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Go (golang) client library for logging to https://logentries.com/ via TLS.  Compatible with http://golang.org/pkg/log/#Logger
 
 * Uses a buffered chan to avoid blocking the application.  Will write to std err if the chan is full.
+* To block on write to Logentries set the env var LOGENTRIES_BLOCKING=true
 
 Example usage:
 


### PR DESCRIPTION
This gives the option to make all writes to Logentries block (and fail after 2 tries) by setting `LOGENTRIES_BLOCKING=true`.

If you would prefer only some log messages to block then I would need to expose a public method for you to use directly.


